### PR TITLE
Playback and notification improvements

### DIFF
--- a/app/src/main/java/fho/kdvs/global/MainActivity.kt
+++ b/app/src/main/java/fho/kdvs/global/MainActivity.kt
@@ -217,7 +217,7 @@ class MainActivity : DaggerAppCompatActivity() {
 
                         kdvsPreferences.lastPlayedBroadcastId = null
                     } else {
-                        nowPlayingBroadcast?.let {
+                        nowPlayingBroadcast.let {
                             setShowTimeOrBroadcastDate(
                                 TimeHelper.uiDateFormatter
                                     .format(nowPlayingBroadcast.date)

--- a/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
+++ b/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
@@ -253,18 +253,7 @@ class SharedViewModel @Inject constructor(
                 try {
                     mediaSessionConnection.transportControls?.prepareFromUri(
                         Uri.fromFile(file),
-                        Bundle().apply {
-                            putInt("SHOW_ID", show.id)
-
-                            kdvsPreferences.lastPlayedBroadcastId?.let {
-                                putLong(
-                                    "POSITION",
-                                    kdvsPreferences.lastPlayedBroadcastPosition ?: 0L
-                                )
-                            }
-
-                            putString("TYPE", PlaybackType.ARCHIVE.type)
-                        }
+                        makeMediaSessionExtras(show)
                     )
                 } catch (e: Exception) {
                     Timber.e("Error with URI playback: $e")
@@ -287,18 +276,7 @@ class SharedViewModel @Inject constructor(
                 try {
                     mediaSessionConnection.transportControls?.prepareFromMediaId(
                         broadcast.broadcastId.toString(),
-                        Bundle().apply {
-                            putInt("SHOW_ID", show.id)
-
-                            kdvsPreferences.lastPlayedBroadcastId?.let {
-                                putLong(
-                                    "POSITION",
-                                    kdvsPreferences.lastPlayedBroadcastPosition ?: 0L
-                                )
-                            }
-
-                            putString("TYPE", PlaybackType.ARCHIVE.type)
-                        }
+                        makeMediaSessionExtras(show)
                     )
                 } catch (e: Exception) {
                     Timber.e("Error with stream playback: $e")
@@ -312,6 +290,19 @@ class SharedViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun makeMediaSessionExtras(show: ShowEntity) = Bundle().apply {
+        putInt("SHOW_ID", show.id)
+
+        kdvsPreferences.lastPlayedBroadcastId?.let {
+            putLong(
+                "POSITION",
+                kdvsPreferences.lastPlayedBroadcastPosition ?: 0L
+            )
+        }
+
+        putString("TYPE", PlaybackType.ARCHIVE.type)
     }
 
     private fun playPastBroadcast(broadcast: BroadcastEntity, show: ShowEntity) {

--- a/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
+++ b/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
@@ -347,8 +347,7 @@ class SharedViewModel @Inject constructor(
         val customAction = CustomAction(
             getApplication(),
             mediaSessionConnection.transportControls,
-            mediaSessionConnection.playbackState.value,
-            mediaSessionConnection
+            mediaSessionConnection.playbackState.value
         )
 
         customAction.live()
@@ -358,8 +357,7 @@ class SharedViewModel @Inject constructor(
         val customAction = CustomAction(
             getApplication(),
             mediaSessionConnection.transportControls,
-            mediaSessionConnection.playbackState.value,
-            mediaSessionConnection
+            mediaSessionConnection.playbackState.value
         )
 
         customAction.replay()
@@ -369,8 +367,7 @@ class SharedViewModel @Inject constructor(
         val customAction = CustomAction(
             getApplication(),
             mediaSessionConnection.transportControls,
-            mediaSessionConnection.playbackState.value,
-            mediaSessionConnection
+            mediaSessionConnection.playbackState.value
         )
 
         customAction.forward()

--- a/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
+++ b/app/src/main/java/fho/kdvs/global/SharedViewModel.kt
@@ -45,6 +45,8 @@ import fho.kdvs.news.NewsRepository
 import fho.kdvs.schedule.QuarterRepository
 import fho.kdvs.schedule.QuarterYear
 import fho.kdvs.services.*
+import fho.kdvs.services.notification.CustomAction
+import fho.kdvs.services.notification.PlaybackType
 import fho.kdvs.show.ShowRepository
 import fho.kdvs.staff.StaffRepository
 import fho.kdvs.subscription.SubscriptionRepository

--- a/app/src/main/java/fho/kdvs/player/PlayerFragment.kt
+++ b/app/src/main/java/fho/kdvs/player/PlayerFragment.kt
@@ -220,7 +220,7 @@ class PlayerFragment : DaggerFragment() {
             sharedViewModel.jumpBack30Seconds()
         }
         archiveControls.exo_play_pause_archive.setOnClickListener {
-            sharedViewModel.playOrPausePlayback(activity)
+            sharedViewModel.playOrPausePlayback(requireActivity())
         }
         archiveControls.exo_forward30.setOnClickListener {
             sharedViewModel.jumpForward30Seconds()
@@ -258,10 +258,10 @@ class PlayerFragment : DaggerFragment() {
             sharedViewModel.stopPlayback()
         }
         liveControls.exo_play_pause_live.setOnClickListener {
-            sharedViewModel.playOrPausePlayback(activity)
+            sharedViewModel.playOrPausePlayback(requireActivity())
         }
         liveControls.exo_live.setOnClickListener {
-            sharedViewModel.prepareLivePlayback()
+            sharedViewModel.goLive()
         }
 
         archiveControls.visibility = View.GONE

--- a/app/src/main/java/fho/kdvs/services/AudioPlayerService.kt
+++ b/app/src/main/java/fho/kdvs/services/AudioPlayerService.kt
@@ -167,8 +167,7 @@ class AudioPlayerService : MediaBrowserServiceCompat() {
                         val customAction = CustomAction(
                             application,
                             controller.transportControls,
-                            mediaController.playbackState,
-                            mediaSessionConnection
+                            mediaController.playbackState
                         )
 
                         when (action) {

--- a/app/src/main/java/fho/kdvs/services/AudioPlayerService.kt
+++ b/app/src/main/java/fho/kdvs/services/AudioPlayerService.kt
@@ -32,6 +32,7 @@ import com.google.android.exoplayer2.ui.PlayerNotificationManager
 import com.google.android.exoplayer2.upstream.HttpDataSource
 import dagger.android.AndroidInjection
 import fho.kdvs.R
+import fho.kdvs.services.notification.*
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -354,11 +355,12 @@ class AudioPlayerService : MediaBrowserServiceCompat() {
                     state
                 ) && playbackType != null
             ) {
-                playbackNotificationBuilder = PlaybackNotificationBuilder(
-                    context,
-                    mediaSession.sessionToken,
-                    playbackType
-                )
+                playbackNotificationBuilder =
+                    PlaybackNotificationBuilder(
+                        context,
+                        mediaSession.sessionToken,
+                        playbackType
+                    )
 
                 playbackNotificationBuilder.build()
             } else null

--- a/app/src/main/java/fho/kdvs/services/CustomActions.kt
+++ b/app/src/main/java/fho/kdvs/services/CustomActions.kt
@@ -119,32 +119,18 @@ class CustomAction @Inject constructor(
     }
 
     fun replay() {
-        val preferences = KdvsPreferences(application)
-
-        if (preferences.offlineMode == true)
-            return
-
         playbackState?.let {
-            if (it.isPlaying) {
-                val currentPos = it.bufferedPosition
-                val newPos = max(0, currentPos - 30000)
-                transportControls?.seekTo(newPos)
-            }
+            val currentPos = it.position
+            val newPos = max(0, currentPos - 30000)
+            transportControls?.seekTo(newPos)
         }
     }
 
     fun forward() {
-        val preferences = KdvsPreferences(application)
-
-        if (preferences.offlineMode == true)
-            return
-
         playbackState?.let {
-            if (it.isPlaying) {
-                val currentPos = it.position
-                val newPos = currentPos + 30000
-                transportControls?.seekTo(newPos) // TODO: test if this works when exceeding duration
-            }
+            val currentPos = it.position
+            val newPos = currentPos + 30000
+            transportControls?.seekTo(newPos)
         }
     }
 }

--- a/app/src/main/java/fho/kdvs/services/MediaSessionConnection.kt
+++ b/app/src/main/java/fho/kdvs/services/MediaSessionConnection.kt
@@ -26,6 +26,8 @@ import android.support.v4.media.session.PlaybackStateCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.media.MediaBrowserServiceCompat
 import fho.kdvs.services.MediaSessionConnection.MediaBrowserConnectionCallback
+import fho.kdvs.services.notification.PlaybackType
+import fho.kdvs.services.notification.PlaybackTypeHelper
 
 /**
  * Class that manages a connection to a [MediaBrowserServiceCompat] instance.

--- a/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
@@ -1,135 +1,166 @@
-/*
- * Copyright 2018 Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package fho.kdvs.services
 
-import android.app.NotificationManager
+import android.app.Notification
 import android.content.Context
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
 import android.support.v4.media.session.PlaybackStateCompat.*
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
 import androidx.media.session.MediaButtonReceiver
 import fho.kdvs.R
-import fho.kdvs.global.extensions.isPlayEnabled
 import fho.kdvs.global.extensions.isPlaying
 
 const val NOW_PLAYING_CHANNEL: String = "fho.kdvs.NOW_PLAYING"
 const val NOW_PLAYING_NOTIFICATION: Int = 0xb339
 
-/**
- * Abstract helper class to encapsulate code for building playback notifications.
- * Concrete classes are instantiated based on [PlaybackType].
- */
-abstract class PlaybackNotificationBuilder(private val context: Context) {
+interface CustomNotificationBuilder {
+    val context: Context
+    val playPause: NotificationCompat.Action
+
+    fun makeCustomBuilder(
+        baseBuilder: NotificationCompat.Builder
+    ): NotificationCompat.Builder
+
+    fun togglePlay() {
+        if (playPause.title == context.getString(R.string.notification_play)) {
+            playPause.icon = R.drawable.exo_controls_pause
+            playPause.title = context.getString(R.string.notification_pause)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
+        } else {
+            playPause.icon = R.drawable.exo_controls_play
+            playPause.title = context.getString(R.string.notification_play)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
+        }
+    }
+}
+
+class PlaybackNotificationBuilder(
+    private val context: Context,
+    sessionToken: MediaSessionCompat.Token,
+    playbackType: PlaybackType
+) {
     lateinit var builder: NotificationCompat.Builder
 
-    val playAction = NotificationCompat.Action(
-        R.drawable.exo_controls_play,
-        context.getString(R.string.notification_play),
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
-    )
+    private val base = makeBaseNotificationBuilder(sessionToken)
 
-    val pauseAction = NotificationCompat.Action(
-        R.drawable.exo_controls_pause,
-        context.getString(R.string.notification_pause),
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
-    )
+    private val controller = MediaControllerCompat(context, sessionToken)
 
-    val stopPendingIntent =
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)
+    private val customNotification = when (playbackType) {
+        PlaybackType.LIVE -> LiveNotificationBuilder(context, controller)
+        PlaybackType.ARCHIVE -> ArchiveNotificationBuilder(context, controller)
+    }
 
-    abstract fun setBuilder(
-        sessionToken: MediaSessionCompat.Token,
-        controller: MediaControllerCompat
-    )
+    fun build(): Notification {
+        return customNotification.makeCustomBuilder(
+            base
+        ).build()
+    }
 
-    fun buildNotification(sessionToken: MediaSessionCompat.Token): NotificationCompat.Builder {
+    fun togglePlay(): Notification {
+        customNotification.togglePlay()
+
+        return build()
+    }
+
+    private fun makeBaseNotificationBuilder(sessionToken: MediaSessionCompat.Token): NotificationCompat.Builder {
         val controller = MediaControllerCompat(context, sessionToken)
-
-        setBuilder(sessionToken, controller)
 
         val description = controller.metadata.description
 
         val mediaStyle = MediaStyle()
-            .setCancelButtonIntent(stopPendingIntent)
+            .setCancelButtonIntent(NotificationHelper.getStopPendingIntent(context))
             .setMediaSession(sessionToken)
 
-        builder = NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
+        return NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
             .setContentIntent(controller.sessionActivity)
-            .setContentText(description.subtitle)
-            .setContentTitle(description.title)
-            .setDeleteIntent(stopPendingIntent)
+            .setContentText(description.subtitle ?: "")
+            .setContentTitle(description.title ?: "")
+            .setDeleteIntent(NotificationHelper.getStopPendingIntent(context))
             .setLargeIcon(description.iconBitmap)
             .setOnlyAlertOnce(true)
             .setSmallIcon(R.drawable.ic_kdvs_head_black)
             .setStyle(mediaStyle)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setShowWhen(false)
-
-        return builder
     }
 }
 
-class LivePlaybackNotificationBuilder(val context: Context) : PlaybackNotificationBuilder(context) {
-    override fun setBuilder(
-        sessionToken: MediaSessionCompat.Token,
-        controller: MediaControllerCompat
-    ) {
-        val customActions = CustomActionDefinitions(context)
-        val playbackState = controller.playbackState
-        builder = NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
+private class LiveNotificationBuilder(
+    val mContext: Context,
+    val controller: MediaControllerCompat
+) :
+    CustomNotificationBuilder {
 
-        if (playbackState.isPlaying) {
-            builder.addAction(pauseAction)
-        } else if (playbackState.isPlayEnabled) {
-            builder.addAction(playAction)
-        }
+    override val playPause: NotificationCompat.Action
+        get() = NotificationHelper.getPlayOrPauseAction(context, controller.playbackState)
 
-        builder.addAction(customActions.liveAction)
+    override val context: Context
+        get() = mContext
 
-        builder.addAction(
-            NotificationCompat.Action(
-                R.drawable.exo_icon_stop,
-                context.getString(R.string.notification_stop),
-                stopPendingIntent
-            )
-        )
+    override fun makeCustomBuilder(
+        baseBuilder: NotificationCompat.Builder
+    ): NotificationCompat.Builder {
+        val customActionDefinitions = CustomActionDefinitions(context)
+
+        return baseBuilder
+            .addAction(playPause)
+            .addAction(customActionDefinitions.liveAction)
+            .addAction(NotificationHelper.getStopAction(context))
     }
 }
 
-class ArchivePlaybackNotificationBuilder(val context: Context) :
-    PlaybackNotificationBuilder(context) {
-    override fun setBuilder(
-        sessionToken: MediaSessionCompat.Token,
-        controller: MediaControllerCompat
-    ) {
-        val customActions = CustomActionDefinitions(context)
-        val playbackState = controller.playbackState
-        builder = NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
+private class ArchiveNotificationBuilder(
+    val mContext: Context,
+    val controller: MediaControllerCompat
+) :
+    CustomNotificationBuilder {
 
-        builder.addAction(customActions.replayAction)
+    override val playPause: NotificationCompat.Action
+        get() = NotificationHelper.getPlayOrPauseAction(context, controller.playbackState)
 
-        if (playbackState.isPlaying) {
-            builder.addAction(pauseAction)
-        } else if (playbackState.isPlayEnabled) {
-            builder.addAction(playAction)
-        }
+    override val context: Context
+        get() = mContext
 
-        builder.addAction(customActions.forwardAction)
+    override fun makeCustomBuilder(
+        baseBuilder: NotificationCompat.Builder
+    ): NotificationCompat.Builder {
+        val customActionDefinitions = CustomActionDefinitions(context)
+
+        return baseBuilder
+            .addAction(customActionDefinitions.replayAction)
+            .addAction(playPause)
+            .addAction(NotificationHelper.getStopAction(context))
+            .addAction(customActionDefinitions.forwardAction)
     }
+}
+
+object NotificationHelper {
+
+    fun getPlayOrPauseAction(context: Context, playbackStateCompat: PlaybackStateCompat) =
+        if (playbackStateCompat.isPlaying) getPauseAction(context) else getPlayAction(context)
+
+    private fun getPlayAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_controls_play,
+        context.getString(R.string.notification_play),
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
+    )
+
+    private fun getPauseAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_controls_pause,
+        context.getString(R.string.notification_pause),
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
+    )
+
+    fun getStopPendingIntent(context: Context) =
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)!!
+
+    fun getStopAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_icon_stop,
+        context.getString(R.string.notification_stop),
+        getStopPendingIntent(context)
+    )
 }

--- a/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
@@ -136,20 +136,3 @@ class ArchivePlaybackNotificationBuilder(val context: Context) :
         builder.addAction(customActions.forwardAction)
     }
 }
-
-class DefaultPlaybackNotificationBuilder(val context: Context) :
-    PlaybackNotificationBuilder(context) {
-    override fun setBuilder(
-        sessionToken: MediaSessionCompat.Token,
-        controller: MediaControllerCompat
-    ) {
-        val playbackState = controller.playbackState
-        builder = NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
-
-        if (playbackState.isPlaying) {
-            builder.addAction(pauseAction)
-        } else if (playbackState.isPlayEnabled) {
-            builder.addAction(playAction)
-        }
-    }
-}

--- a/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
@@ -15,37 +15,12 @@ import fho.kdvs.global.extensions.isPlaying
 const val NOW_PLAYING_CHANNEL: String = "fho.kdvs.NOW_PLAYING"
 const val NOW_PLAYING_NOTIFICATION: Int = 0xb339
 
-interface CustomNotificationBuilder {
-    val context: Context
-    val playPause: NotificationCompat.Action
-
-    fun makeCustomBuilder(
-        baseBuilder: NotificationCompat.Builder
-    ): NotificationCompat.Builder
-
-    fun togglePlay() {
-        if (playPause.title == context.getString(R.string.notification_play)) {
-            playPause.icon = R.drawable.exo_controls_pause
-            playPause.title = context.getString(R.string.notification_pause)
-            playPause.actionIntent =
-                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
-        } else {
-            playPause.icon = R.drawable.exo_controls_play
-            playPause.title = context.getString(R.string.notification_play)
-            playPause.actionIntent =
-                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
-        }
-    }
-}
-
 class PlaybackNotificationBuilder(
     private val context: Context,
-    sessionToken: MediaSessionCompat.Token,
+    private val sessionToken: MediaSessionCompat.Token,
     playbackType: PlaybackType
 ) {
     lateinit var builder: NotificationCompat.Builder
-
-    private val base = makeBaseNotificationBuilder(sessionToken)
 
     private val controller = MediaControllerCompat(context, sessionToken)
 
@@ -56,7 +31,7 @@ class PlaybackNotificationBuilder(
 
     fun build(): Notification {
         return customNotification.makeCustomBuilder(
-            base
+            makeBaseNotificationBuilder(sessionToken)
         ).build()
     }
 
@@ -85,7 +60,31 @@ class PlaybackNotificationBuilder(
             .setSmallIcon(R.drawable.ic_kdvs_head_black)
             .setStyle(mediaStyle)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setWhen(0)
             .setShowWhen(false)
+    }
+}
+
+interface CustomNotificationBuilder {
+    val context: Context
+    val playPause: NotificationCompat.Action
+
+    fun makeCustomBuilder(
+        baseBuilder: NotificationCompat.Builder
+    ): NotificationCompat.Builder
+
+    fun togglePlay() {
+        if (playPause.title == context.getString(R.string.notification_play)) {
+            playPause.icon = R.drawable.exo_controls_pause
+            playPause.title = context.getString(R.string.notification_pause)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
+        } else {
+            playPause.icon = R.drawable.exo_controls_play
+            playPause.title = context.getString(R.string.notification_play)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
+        }
     }
 }
 
@@ -131,10 +130,10 @@ private class ArchiveNotificationBuilder(
         val customActionDefinitions = CustomActionDefinitions(context)
 
         return baseBuilder
-            .addAction(customActionDefinitions.replayAction)
             .addAction(playPause)
-            .addAction(NotificationHelper.getStopAction(context))
+            .addAction(customActionDefinitions.replayAction)
             .addAction(customActionDefinitions.forwardAction)
+            .addAction(NotificationHelper.getStopAction(context))
     }
 }
 

--- a/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/PlaybackNotificationBuilder.kt
@@ -38,9 +38,6 @@ const val NOW_PLAYING_NOTIFICATION: Int = 0xb339
 abstract class PlaybackNotificationBuilder(private val context: Context) {
     lateinit var builder: NotificationCompat.Builder
 
-    private val platformNotificationManager: NotificationManager =
-        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
     val playAction = NotificationCompat.Action(
         R.drawable.exo_controls_play,
         context.getString(R.string.notification_play),

--- a/app/src/main/java/fho/kdvs/services/notification/CustomActions.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/CustomActions.kt
@@ -1,4 +1,4 @@
-package fho.kdvs.services
+package fho.kdvs.services.notification
 
 import android.app.Application
 import android.app.PendingIntent
@@ -14,6 +14,7 @@ import fho.kdvs.global.extensions.isPlaying
 import fho.kdvs.global.extensions.isPrepared
 import fho.kdvs.global.preferences.KdvsPreferences
 import fho.kdvs.global.util.URLs
+import fho.kdvs.services.MediaSessionConnection
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.max

--- a/app/src/main/java/fho/kdvs/services/notification/CustomActions.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/CustomActions.kt
@@ -8,14 +8,11 @@ import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.core.app.NotificationCompat
 import fho.kdvs.R
-import fho.kdvs.global.extensions.id
-import fho.kdvs.global.extensions.isPlayEnabled
 import fho.kdvs.global.extensions.isPlaying
 import fho.kdvs.global.extensions.isPrepared
 import fho.kdvs.global.preferences.KdvsPreferences
 import fho.kdvs.global.util.URLs
 import fho.kdvs.services.MediaSessionConnection
-import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.max
 
@@ -84,8 +81,7 @@ class CustomActionDefinitions(val context: Context) {
 class CustomAction @Inject constructor(
     private val application: Application,
     private val transportControls: MediaControllerCompat.TransportControls?,
-    private val playbackState: PlaybackStateCompat?,
-    private val mediaSessionConnection: MediaSessionConnection
+    private val playbackState: PlaybackStateCompat?
 ) {
 
     fun live() {
@@ -96,26 +92,16 @@ class CustomAction @Inject constructor(
 
         val streamUrl = preferences.streamUrl ?: URLs.LIVE_OGG
         val isPrepared = playbackState?.isPrepared ?: false
-        val nowPlaying = mediaSessionConnection.nowPlaying.value
 
         transportControls?.let {
-            if (isPrepared && streamUrl == nowPlaying?.id) {
+            if (isPrepared) {
                 playbackState?.let {
-                    when {
-                        it.isPlaying -> {
-                            transportControls.pause()
-                        }
-                        it.isPlayEnabled -> {
-                            transportControls.play()
-                        }
-                        else -> {
-                            Timber.w("Playable item clicked but neither play nor pause are enabled! (mediaId=$streamUrl)")
-                        }
-                    }
+                    if (it.isPlaying)
+                        transportControls.stop()
                 }
-            } else {
-                transportControls.playFromMediaId(streamUrl, null)
             }
+
+            transportControls.playFromMediaId(streamUrl, null)
         }
     }
 

--- a/app/src/main/java/fho/kdvs/services/notification/CustomNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/CustomNotificationBuilder.kt
@@ -1,0 +1,36 @@
+package fho.kdvs.services.notification
+
+import android.content.Context
+import android.support.v4.media.session.PlaybackStateCompat
+import androidx.core.app.NotificationCompat
+import androidx.media.session.MediaButtonReceiver
+import fho.kdvs.R
+
+interface CustomNotificationBuilder {
+    val context: Context
+    val playPause: NotificationCompat.Action
+
+    fun makeCustomBuilder(
+        baseBuilder: NotificationCompat.Builder
+    ): NotificationCompat.Builder
+
+    fun togglePlay() {
+        if (playPause.title == context.getString(R.string.notification_play)) {
+            playPause.icon = R.drawable.exo_controls_pause
+            playPause.title = context.getString(R.string.notification_pause)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    context,
+                    PlaybackStateCompat.ACTION_PAUSE
+                )
+        } else {
+            playPause.icon = R.drawable.exo_controls_play
+            playPause.title = context.getString(R.string.notification_play)
+            playPause.actionIntent =
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    context,
+                    PlaybackStateCompat.ACTION_PLAY
+                )
+        }
+    }
+}

--- a/app/src/main/java/fho/kdvs/services/notification/NotificationHelper.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/NotificationHelper.kt
@@ -1,0 +1,37 @@
+package fho.kdvs.services.notification
+
+import android.content.Context
+import android.support.v4.media.session.PlaybackStateCompat
+import androidx.core.app.NotificationCompat
+import androidx.media.session.MediaButtonReceiver
+import fho.kdvs.R
+import fho.kdvs.global.extensions.isPlaying
+
+object NotificationHelper {
+
+    fun getPlayOrPauseAction(context: Context, playbackStateCompat: PlaybackStateCompat) =
+        if (playbackStateCompat.isPlaying) getPauseAction(
+            context
+        ) else getPlayAction(context)
+
+    private fun getPlayAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_controls_play,
+        context.getString(R.string.notification_play),
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_PLAY)
+    )
+
+    private fun getPauseAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_controls_pause,
+        context.getString(R.string.notification_pause),
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_PAUSE)
+    )
+
+    fun getStopPendingIntent(context: Context) =
+        MediaButtonReceiver.buildMediaButtonPendingIntent(context, PlaybackStateCompat.ACTION_STOP)!!
+
+    fun getStopAction(context: Context) = NotificationCompat.Action(
+        R.drawable.exo_icon_stop,
+        context.getString(R.string.notification_stop),
+        getStopPendingIntent(context)
+    )
+}

--- a/app/src/main/java/fho/kdvs/services/notification/PlaybackNotificationBuilder.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/PlaybackNotificationBuilder.kt
@@ -1,16 +1,12 @@
-package fho.kdvs.services
+package fho.kdvs.services.notification
 
 import android.app.Notification
 import android.content.Context
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
-import android.support.v4.media.session.PlaybackStateCompat
-import android.support.v4.media.session.PlaybackStateCompat.*
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
-import androidx.media.session.MediaButtonReceiver
 import fho.kdvs.R
-import fho.kdvs.global.extensions.isPlaying
 
 const val NOW_PLAYING_CHANNEL: String = "fho.kdvs.NOW_PLAYING"
 const val NOW_PLAYING_NOTIFICATION: Int = 0xb339
@@ -25,8 +21,14 @@ class PlaybackNotificationBuilder(
     private val controller = MediaControllerCompat(context, sessionToken)
 
     private val customNotification = when (playbackType) {
-        PlaybackType.LIVE -> LiveNotificationBuilder(context, controller)
-        PlaybackType.ARCHIVE -> ArchiveNotificationBuilder(context, controller)
+        PlaybackType.LIVE -> LiveNotificationBuilder(
+            context,
+            controller
+        )
+        PlaybackType.ARCHIVE -> ArchiveNotificationBuilder(
+            context,
+            controller
+        )
     }
 
     fun build(): Notification {
@@ -47,14 +49,25 @@ class PlaybackNotificationBuilder(
         val description = controller.metadata.description
 
         val mediaStyle = MediaStyle()
-            .setCancelButtonIntent(NotificationHelper.getStopPendingIntent(context))
+            .setCancelButtonIntent(
+                NotificationHelper.getStopPendingIntent(
+                    context
+                )
+            )
             .setMediaSession(sessionToken)
 
-        return NotificationCompat.Builder(context, NOW_PLAYING_CHANNEL)
+        return NotificationCompat.Builder(
+            context,
+            NOW_PLAYING_CHANNEL
+        )
             .setContentIntent(controller.sessionActivity)
             .setContentText(description.subtitle ?: "")
             .setContentTitle(description.title ?: "")
-            .setDeleteIntent(NotificationHelper.getStopPendingIntent(context))
+            .setDeleteIntent(
+                NotificationHelper.getStopPendingIntent(
+                    context
+                )
+            )
             .setLargeIcon(description.iconBitmap)
             .setOnlyAlertOnce(true)
             .setSmallIcon(R.drawable.ic_kdvs_head_black)
@@ -65,28 +78,6 @@ class PlaybackNotificationBuilder(
     }
 }
 
-interface CustomNotificationBuilder {
-    val context: Context
-    val playPause: NotificationCompat.Action
-
-    fun makeCustomBuilder(
-        baseBuilder: NotificationCompat.Builder
-    ): NotificationCompat.Builder
-
-    fun togglePlay() {
-        if (playPause.title == context.getString(R.string.notification_play)) {
-            playPause.icon = R.drawable.exo_controls_pause
-            playPause.title = context.getString(R.string.notification_pause)
-            playPause.actionIntent =
-                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
-        } else {
-            playPause.icon = R.drawable.exo_controls_play
-            playPause.title = context.getString(R.string.notification_play)
-            playPause.actionIntent =
-                MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
-        }
-    }
-}
 
 private class LiveNotificationBuilder(
     val mContext: Context,
@@ -95,7 +86,10 @@ private class LiveNotificationBuilder(
     CustomNotificationBuilder {
 
     override val playPause: NotificationCompat.Action
-        get() = NotificationHelper.getPlayOrPauseAction(context, controller.playbackState)
+        get() = NotificationHelper.getPlayOrPauseAction(
+            context,
+            controller.playbackState
+        )
 
     override val context: Context
         get() = mContext
@@ -103,7 +97,8 @@ private class LiveNotificationBuilder(
     override fun makeCustomBuilder(
         baseBuilder: NotificationCompat.Builder
     ): NotificationCompat.Builder {
-        val customActionDefinitions = CustomActionDefinitions(context)
+        val customActionDefinitions =
+            CustomActionDefinitions(context)
 
         return baseBuilder
             .addAction(playPause)
@@ -119,7 +114,10 @@ private class ArchiveNotificationBuilder(
     CustomNotificationBuilder {
 
     override val playPause: NotificationCompat.Action
-        get() = NotificationHelper.getPlayOrPauseAction(context, controller.playbackState)
+        get() = NotificationHelper.getPlayOrPauseAction(
+            context,
+            controller.playbackState
+        )
 
     override val context: Context
         get() = mContext
@@ -127,7 +125,8 @@ private class ArchiveNotificationBuilder(
     override fun makeCustomBuilder(
         baseBuilder: NotificationCompat.Builder
     ): NotificationCompat.Builder {
-        val customActionDefinitions = CustomActionDefinitions(context)
+        val customActionDefinitions =
+            CustomActionDefinitions(context)
 
         return baseBuilder
             .addAction(playPause)
@@ -135,31 +134,4 @@ private class ArchiveNotificationBuilder(
             .addAction(customActionDefinitions.forwardAction)
             .addAction(NotificationHelper.getStopAction(context))
     }
-}
-
-object NotificationHelper {
-
-    fun getPlayOrPauseAction(context: Context, playbackStateCompat: PlaybackStateCompat) =
-        if (playbackStateCompat.isPlaying) getPauseAction(context) else getPlayAction(context)
-
-    private fun getPlayAction(context: Context) = NotificationCompat.Action(
-        R.drawable.exo_controls_play,
-        context.getString(R.string.notification_play),
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PLAY)
-    )
-
-    private fun getPauseAction(context: Context) = NotificationCompat.Action(
-        R.drawable.exo_controls_pause,
-        context.getString(R.string.notification_pause),
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_PAUSE)
-    )
-
-    fun getStopPendingIntent(context: Context) =
-        MediaButtonReceiver.buildMediaButtonPendingIntent(context, ACTION_STOP)!!
-
-    fun getStopAction(context: Context) = NotificationCompat.Action(
-        R.drawable.exo_icon_stop,
-        context.getString(R.string.notification_stop),
-        getStopPendingIntent(context)
-    )
 }

--- a/app/src/main/java/fho/kdvs/services/notification/PlaybackType.kt
+++ b/app/src/main/java/fho/kdvs/services/notification/PlaybackType.kt
@@ -1,4 +1,4 @@
-package fho.kdvs.services
+package fho.kdvs.services.notification
 
 import android.content.Context
 import fho.kdvs.R

--- a/app/src/main/java/fho/kdvs/show/ShowRepository.kt
+++ b/app/src/main/java/fho/kdvs/show/ShowRepository.kt
@@ -112,14 +112,15 @@ class ShowRepository @Inject constructor(
     }
 
     /** A [MediatorLiveData] which merges the currently playing show and currently playing broadcast. */
-    val nowPlayingStreamLiveData = MediatorLiveData<Pair<ShowEntity, BroadcastEntity?>>()
+    val nowPlayingStreamLiveData = MediatorLiveData<Pair<ShowEntity, BroadcastEntity>>()
         .apply {
             var broadcast: BroadcastEntity? = null
             var show: ShowEntity? = null
 
             addSource(broadcastRepository.nowPlayingShowLiveData) { showEntity ->
                 show = showEntity
-                postValue(Pair(showEntity, broadcast))
+                val broadcastEntity = broadcast ?: return@addSource
+                postValue(Pair(showEntity, broadcastEntity))
             }
 
             addSource(broadcastRepository.nowPlayingBroadcastLiveData) { broadcastEntity ->


### PR DESCRIPTION
Rewrote the custom exoplayer notification code, which fixed most of the glaring issues. (#24, #45)

Also uncovered a few extant issues regarding playback preparation.

Still a couple of minor things to work out. For whatever reason, the smallIcon and setWhen builder settings aren't displaying. Also, when the 'Go Live' control recreates the notification, it sometimes shows a brief null notification in between builds, which looks a little awkward.